### PR TITLE
Use sort-package-json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "fix"]
+        "cacheableOperations": ["build", "fix", "sort"]
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Unlicense",
       "devDependencies": {
         "nx": "16.5.5",
+        "sort-package-json": "^2.5.1",
         "ts-standard": "^12.0.2",
         "typescript": "^5.1.6"
       }
@@ -1089,6 +1090,27 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+      "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.0.tgz",
+      "integrity": "sha512-1aXUEPdfGdzVPFpzGJJNgq9o81bGg1s09uxTWsqBlo9PI332uyJRQq13+LK/UN4JfxJbFdCXonUFQ9R/p7yCtw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2102,6 +2124,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/git-hooks-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz",
+      "integrity": "sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2548,6 +2579,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -3817,6 +3860,73 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sort-object-keys": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+      "dev": true
+    },
+    "node_modules/sort-package-json": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.5.1.tgz",
+      "integrity": "sha512-vx/KoZxm8YNMUqdlw7SGTfqR5pqZ/sUfgOuRtDILiOy/3AvzhAibyUe2cY3OpLs3oRSow9up4yLVtQaM24rbDQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-indent": "^7.0.1",
+        "detect-newline": "^4.0.0",
+        "get-stdin": "^9.0.0",
+        "git-hooks-list": "^3.0.0",
+        "globby": "^13.1.2",
+        "is-plain-obj": "^4.1.0",
+        "sort-object-keys": "^1.1.3"
+      },
+      "bin": {
+        "sort-package-json": "cli.js"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -11,39 +11,57 @@
     "url": "https://github.com/threeal/node-ts-starter/issues",
     "email": "threeal@github.com"
   },
+  "repository": "github:threeal/node-ts-starter",
   "license": "Unlicense",
   "author": "threeal <threeal@github.com>",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
-  "repository": "github:threeal/node-ts-starter",
   "scripts": {
     "build": "nx exec -- tsc",
-    "fix": "nx exec -- ts-standard --fix"
+    "fix": "nx exec -- ts-standard --fix",
+    "sort": "nx exec -- sort-package-json"
   },
   "devDependencies": {
+    "nx": "16.5.5",
+    "sort-package-json": "^2.5.1",
     "ts-standard": "^12.0.2",
-    "typescript": "^5.1.6",
-    "nx": "16.5.5"
+    "typescript": "^5.1.6"
+  },
+  "nx": {
+    "namedInputs": {
+      "default": [
+        "{projectRoot}/**/*"
+      ]
+    },
+    "targets": {
+      "build": {
+        "inputs": [
+          "default"
+        ],
+        "dependsOn": [
+          "fix"
+        ]
+      },
+      "fix": {
+        "inputs": [
+          "default"
+        ],
+        "dependsOn": [
+          "sort"
+        ]
+      },
+      "sort": {
+        "inputs": [
+          "default"
+        ]
+      }
+    }
   },
   "ts-standard": {
     "ignore": [
       "dist"
     ]
-  },
-  "nx": {
-    "namedInputs": {
-      "default": ["{projectRoot}/**/*"]
-    },
-    "targets": {
-      "build": {
-        "inputs": ["default"],
-        "dependsOn": ["fix"]
-      },
-      "fix": {
-        "inputs": ["default"]
-      }
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,11 +51,6 @@
         "dependsOn": [
           "sort"
         ]
-      },
-      "sort": {
-        "inputs": [
-          "default"
-        ]
       }
     }
   },


### PR DESCRIPTION
This pull request implements the use of [sort-package-json](https://www.npmjs.com/package/sort-package-json) to automatically sort the `package.json` file. By incorporating sort-package-json, we ensure a consistently organized `package.json` with sorted dependencies, scripts, and other properties. This pull request effectively closes #12.