### PR TITLE
Audit Nx Tasks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
         run: yarn clean
 
       - name: Build dist
-        run: yarn build
+        run: yarn nx build
 
       - name: Check diff
         run: git diff --exit-code HEAD

--- a/nx.json
+++ b/nx.json
@@ -6,5 +6,22 @@
         "cacheableOperations": ["build", "format", "lint", "sort"]
       }
     }
+  },
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"]
+  },
+  "targetDefaults": {
+    "build": {
+      "inputs": ["default"],
+      "dependsOn": ["lint"]
+    },
+    "format": {
+      "inputs": ["default"],
+      "dependsOn": ["sort"]
+    },
+    "lint": {
+      "inputs": ["default"],
+      "dependsOn": ["format"]
+    }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -22,6 +22,9 @@
     "lint": {
       "inputs": ["default"],
       "dependsOn": ["format"]
+    },
+    "test": {
+      "dependsOn": ["build"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -8,20 +8,36 @@
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*"]
+    "dependencies": [
+      "{projectRoot}/.pnp.*",
+      "{projectRoot}/.yarn*",
+      "{projectRoot}/package.json"
+    ]
   },
   "targetDefaults": {
     "build": {
-      "inputs": ["default"],
-      "dependsOn": ["lint"]
+      "dependsOn": ["lint"],
+      "inputs": [
+        "dependencies",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/tsconfig.json"
+      ]
     },
     "format": {
-      "inputs": ["default"],
-      "dependsOn": ["sort"]
+      "dependsOn": ["sort"],
+      "inputs": ["dependencies", "{projectRoot}/**/*", "{projectRoot}/**/.*"]
     },
     "lint": {
-      "inputs": ["default"],
-      "dependsOn": ["format"]
+      "dependsOn": ["format"],
+      "inputs": [
+        "dependencies",
+        "{projectRoot}/src/**/*",
+        "{projectRoot}/test/**/*",
+        "{projectRoot}/.eslintrc.json"
+      ]
+    },
+    "sort": {
+      "inputs": ["dependencies"]
     },
     "test": {
       "dependsOn": ["build"]

--- a/package.json
+++ b/package.json
@@ -42,37 +42,5 @@
     "typescript": "^5.1.6"
   },
   "packageManager": "yarn@3.6.1",
-  "nx": {
-    "namedInputs": {
-      "default": [
-        "{projectRoot}/**/*"
-      ]
-    },
-    "targets": {
-      "build": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "lint"
-        ]
-      },
-      "format": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "sort"
-        ]
-      },
-      "lint": {
-        "inputs": [
-          "default"
-        ],
-        "dependsOn": [
-          "format"
-        ]
-      }
-    }
-  }
+  "nx": {}
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "nx exec -- tsc",
-    "clean": "nx exec -- rimraf dist",
-    "format": "nx exec -- prettier --write .",
-    "lint": "nx exec -- eslint src test",
-    "sort": "nx exec -- sort-package-json",
-    "test": "nx exec -- c8 mocha"
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "format": "prettier --write .",
+    "lint": "eslint src test",
+    "sort": "sort-package-json",
+    "test": "c8 mocha"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",


### PR DESCRIPTION
This pull request makes the following modifications to the Nx configuration:

- Moves Nx inputs and task declarations from the `package.json` to the `nx.json`.
- Updates scripts in the `package.json` to no longer use the `nx exec` commands. Instead, it is now recommended to directly run the `nx` command (e.g., `yarn nx run build`) to utilize Nx effectively.
- Adjusts the inputs of each task to ensure caching is triggered only if the appropriate files are changed.

These changes retain the usage of Nx in this project while improving the organization and efficiency of our tasks. This pull request effectively closes #36.