### PR TITLE
Use `chai/register-should.js`

### DIFF
--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -1,7 +1,5 @@
-import * as chai from "chai";
+import "chai/register-should.js";
 import { isOdd, isEven } from "../dist/index.mjs";
-
-chai.should();
 
 it("should be odd", () => {
   const val = 5;


### PR DESCRIPTION
This pull request simplifies the registration of [Chai's should style](https://www.chaijs.com/api/bdd/) by importing `chai/register-should.js` instead of using the `chai.should()` function. 