### PR TITLE
Enable All ESLint Rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "sourceType": "module"
   },
   "rules": {
-    "func-style": ["error", "declaration"]
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,11 @@
   "overrides": [
     {
       "files": ["**/*.mts"],
-      "extends": ["plugin:@typescript-eslint/recommended"],
+      "extends": ["plugin:@typescript-eslint/all", "prettier"],
       "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      },
       "plugins": ["@typescript-eslint", "eslint-plugin-tsdoc"],
       "rules": {
         "tsdoc/syntax": "error"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:all", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
     "ecmaVersion": 2022,
     "sourceType": "module"
   },
+  "rules": {
+    "func-style": ["error", "declaration"]
+  },
   "overrides": [
     {
       "files": ["**/*.mts"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "sourceType": "module"
   },
   "rules": {
-    "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
+    "one-var": ["error", "never"]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,9 @@
       "files": ["**/*.test.mjs"],
       "env": {
         "mocha": true
+      },
+      "rules": {
+        "no-unused-expressions": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "eslint": "^8.46.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "esmock": "^2.3.6",
     "mocha": "^10.2.0",

--- a/test/ping.test.mjs
+++ b/test/ping.test.mjs
@@ -1,5 +1,5 @@
-import esmock from "esmock";
 import { createRequire } from "module";
+import esmock from "esmock";
 import path from "path";
 import sinon from "sinon";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-config-prettier@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "eslint-config-prettier@npm:9.0.0"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 362e991b6cb343f79362bada2d97c202e5303e6865888918a7445c555fb75e4c078b01278e90be98aa98ae22f8597d8e93d48314bec6824f540f7efcab3ce451
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-tsdoc@npm:^0.2.17":
   version: 0.2.17
   resolution: "eslint-plugin-tsdoc@npm:0.2.17"
@@ -3255,6 +3266,7 @@ __metadata:
     chai: ^4.3.7
     chai-as-promised: ^7.1.1
     eslint: ^8.46.0
+    eslint-config-prettier: ^9.0.0
     eslint-plugin-tsdoc: ^0.2.17
     esmock: ^2.3.6
     mocha: ^10.2.0


### PR DESCRIPTION
This pull request enables all ESLint rules, including those from [typescript-eslint](https://typescript-eslint.io/), within this template. By enabling all rules, we ensure a comprehensive code analysis that promotes code quality and consistency. This pull request also addresses errors that arose after enabling these rules and introduces [eslint-config-prettier](https://www.npmjs.com/package/eslint-config-prettier) to prevent conflicts with Prettier's formatting rules.