### PR TITLE
Remove Yarn From Nx Inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -8,11 +8,7 @@
     }
   },
   "namedInputs": {
-    "dependencies": [
-      "{projectRoot}/.pnp.*",
-      "{projectRoot}/.yarn*",
-      "{projectRoot}/package.json"
-    ]
+    "dependencies": ["{projectRoot}/.pnp.*", "{projectRoot}/package.json"]
   },
   "targetDefaults": {
     "build": {


### PR DESCRIPTION
This pull request removes the `.yarn*` files from the inputs specified in the Nx configuration. 